### PR TITLE
[NIT-2433] Add option to only track edges part of a specific challenge

### DIFF
--- a/challenge-manager/chain-watcher/watcher.go
+++ b/challenge-manager/chain-watcher/watcher.go
@@ -73,20 +73,22 @@ type trackedChallenge struct {
 // are used during the confirmation process in edge tracker goroutines.
 type Watcher struct {
 	stopwaiter.StopWaiter
-	histChecker                         l2stateprovider.HistoryChecker
-	chain                               protocol.AssertionChain
-	edgeManager                         EdgeManager
-	pollEventsInterval                  time.Duration
-	challenges                          *threadsafe.Map[protocol.AssertionHash, *trackedChallenge]
-	backend                             bind.ContractBackend
-	validatorName                       string
-	numBigStepLevels                    uint8
-	initialSyncCompleted                atomic.Bool
-	apiDB                               db.Database
-	assertionConfirmingInterval         time.Duration
-	averageTimeForBlockCreation         time.Duration
-	evilEdgesByLevel                    *threadsafe.Map[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]]
-	trackChallengeParentAssertionHashes []protocol.AssertionHash // Only track challenges for these parent assertion hashes. Track all if empty / nil.
+	histChecker                 l2stateprovider.HistoryChecker
+	chain                       protocol.AssertionChain
+	edgeManager                 EdgeManager
+	pollEventsInterval          time.Duration
+	challenges                  *threadsafe.Map[protocol.AssertionHash, *trackedChallenge]
+	backend                     bind.ContractBackend
+	validatorName               string
+	numBigStepLevels            uint8
+	initialSyncCompleted        atomic.Bool
+	apiDB                       db.Database
+	assertionConfirmingInterval time.Duration
+	averageTimeForBlockCreation time.Duration
+	evilEdgesByLevel            *threadsafe.Map[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]]
+	// Optional list of challenges to track, keyed by challenged parent assertion hash. If nil,
+	// all challenges will be tracked.
+	challengesToTrack []protocol.AssertionHash
 }
 
 // New initializes a watcher service for frequently scanning the chain
@@ -102,25 +104,25 @@ func New(
 	apiDB db.Database,
 	assertionConfirmingInterval time.Duration,
 	averageTimeForBlockCreation time.Duration,
-	trackChallengeParentAssertionHashes []protocol.AssertionHash,
+	challengesToTrack []protocol.AssertionHash,
 ) (*Watcher, error) {
 	if interval == 0 {
 		return nil, errors.New("chain watcher polling interval must be greater than 0")
 	}
 	return &Watcher{
-		chain:                               chain,
-		edgeManager:                         edgeManager,
-		pollEventsInterval:                  interval,
-		challenges:                          threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](threadsafe.MapWithMetric[protocol.AssertionHash, *trackedChallenge]("challenges")),
-		backend:                             backend,
-		histChecker:                         histChecker,
-		numBigStepLevels:                    numBigStepLevels,
-		validatorName:                       validatorName,
-		apiDB:                               apiDB,
-		assertionConfirmingInterval:         assertionConfirmingInterval,
-		averageTimeForBlockCreation:         averageTimeForBlockCreation,
-		evilEdgesByLevel:                    threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]](threadsafe.MapWithMetric[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]]("evilEdgesByLevel")),
-		trackChallengeParentAssertionHashes: trackChallengeParentAssertionHashes,
+		chain:                       chain,
+		edgeManager:                 edgeManager,
+		pollEventsInterval:          interval,
+		challenges:                  threadsafe.NewMap[protocol.AssertionHash, *trackedChallenge](threadsafe.MapWithMetric[protocol.AssertionHash, *trackedChallenge]("challenges")),
+		backend:                     backend,
+		histChecker:                 histChecker,
+		numBigStepLevels:            numBigStepLevels,
+		validatorName:               validatorName,
+		apiDB:                       apiDB,
+		assertionConfirmingInterval: assertionConfirmingInterval,
+		averageTimeForBlockCreation: averageTimeForBlockCreation,
+		evilEdgesByLevel:            threadsafe.NewMap[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]](threadsafe.MapWithMetric[protocol.ChallengeLevel, *threadsafe.Set[protocol.EdgeId]]("evilEdgesByLevel")),
+		challengesToTrack:           challengesToTrack,
 	}, nil
 }
 
@@ -642,17 +644,19 @@ func (w *Watcher) processEdgeAddedEvent(
 	if err != nil {
 		return false, err
 	}
-	if !w.allowTrackingEdgeWithChallengeParentAssertionHash(challengeParentAssertionHash) {
+	// If we specified a list of challenges we should track, we should
+	// ignore those that are on that list.
+	if !w.shouldTrackChallenge(challengeParentAssertionHash) {
 		return false, nil
 	}
 	return w.AddEdge(ctx, edgeOpt.Unwrap())
 }
 
-func (w *Watcher) allowTrackingEdgeWithChallengeParentAssertionHash(challengeParentAssertionHash protocol.AssertionHash) bool {
-	if len(w.trackChallengeParentAssertionHashes) == 0 {
+func (w *Watcher) shouldTrackChallenge(challengeParentAssertionHash protocol.AssertionHash) bool {
+	if len(w.challengesToTrack) == 0 {
 		return true
 	}
-	for _, hash := range w.trackChallengeParentAssertionHashes {
+	for _, hash := range w.challengesToTrack {
 		if hash == challengeParentAssertionHash {
 			return true
 		}
@@ -760,7 +764,7 @@ func (w *Watcher) processEdgeConfirmation(
 		return err
 	}
 
-	if !w.allowTrackingEdgeWithChallengeParentAssertionHash(challengeParentAssertionHash) {
+	if !w.shouldTrackChallenge(challengeParentAssertionHash) {
 		return nil
 	}
 

--- a/challenge-manager/manager.go
+++ b/challenge-manager/manager.go
@@ -49,32 +49,33 @@ type Opt = func(val *Manager)
 // an active participant in interacting with the on-chain contracts.
 type Manager struct {
 	stopwaiter.StopWaiter
-	chain                               protocol.Protocol
-	chalManagerAddr                     common.Address
-	rollupAddr                          common.Address
-	rollup                              *rollupgen.RollupCore
-	rollupFilterer                      *rollupgen.RollupCoreFilterer
-	chalManager                         *challengeV2gen.EdgeChallengeManagerFilterer
-	backend                             bind.ContractBackend
-	client                              *rpc.Client
-	stateManager                        l2stateprovider.Provider
-	address                             common.Address
-	name                                string
-	timeRef                             utilTime.Reference
-	edgeTrackerWakeInterval             time.Duration
-	chainWatcherInterval                time.Duration
-	watcher                             *watcher.Watcher
-	trackedEdgeIds                      *threadsafe.Map[protocol.EdgeId, *edgetracker.Tracker]
-	batchIndexForAssertionCache         *threadsafe.LruMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]
-	trackChallengeParentAssertionHashes []protocol.AssertionHash // Only track challenges for these parent assertion hashes. Track all if empty / nil.
-	assertionManager                    *assertions.Manager
-	assertionPostingInterval            time.Duration
-	assertionScanningInterval           time.Duration
-	assertionConfirmingInterval         time.Duration
-	averageTimeForBlockCreation         time.Duration
-	mode                                types.Mode
-	maxDelaySeconds                     int
-
+	chain                       protocol.Protocol
+	chalManagerAddr             common.Address
+	rollupAddr                  common.Address
+	rollup                      *rollupgen.RollupCore
+	rollupFilterer              *rollupgen.RollupCoreFilterer
+	chalManager                 *challengeV2gen.EdgeChallengeManagerFilterer
+	backend                     bind.ContractBackend
+	client                      *rpc.Client
+	stateManager                l2stateprovider.Provider
+	address                     common.Address
+	name                        string
+	timeRef                     utilTime.Reference
+	edgeTrackerWakeInterval     time.Duration
+	chainWatcherInterval        time.Duration
+	watcher                     *watcher.Watcher
+	trackedEdgeIds              *threadsafe.Map[protocol.EdgeId, *edgetracker.Tracker]
+	batchIndexForAssertionCache *threadsafe.LruMap[protocol.AssertionHash, edgetracker.AssociatedAssertionMetadata]
+	// Optional list of challenges to track, keyed by challenged parent assertion hash. If nil,
+	// all challenges will be tracked.
+	challengesToTrack            []protocol.AssertionHash
+	assertionManager             *assertions.Manager
+	assertionPostingInterval     time.Duration
+	assertionScanningInterval    time.Duration
+	assertionConfirmingInterval  time.Duration
+	averageTimeForBlockCreation  time.Duration
+	mode                         types.Mode
+	maxDelaySeconds              int
 	claimedAssertionsInChallenge *threadsafe.LruSet[protocol.AssertionHash]
 	// API
 	apiAddr   string
@@ -150,11 +151,11 @@ func WithRPCClient(client *rpc.Client) Opt {
 	}
 }
 
-func WithTrackChallengeParentAssertionHashes(trackChallengeParentAssertionHashes []string) Opt {
+func WithChallengesToTrack(parentAssertionHashes []string) Opt {
 	return func(val *Manager) {
-		val.trackChallengeParentAssertionHashes = make([]protocol.AssertionHash, len(trackChallengeParentAssertionHashes))
-		for i, hash := range trackChallengeParentAssertionHashes {
-			val.trackChallengeParentAssertionHashes[i] = protocol.AssertionHash{Hash: common.HexToHash(hash)}
+		val.challengesToTrack = make([]protocol.AssertionHash, len(parentAssertionHashes))
+		for i, hash := range parentAssertionHashes {
+			val.challengesToTrack[i] = protocol.AssertionHash{Hash: common.HexToHash(hash)}
 		}
 	}
 }
@@ -233,7 +234,7 @@ func New(
 		m.apiDB = apiDB
 	}
 
-	watcher, err := watcher.New(m.chain, m, m.stateManager, m.backend, m.chainWatcherInterval, numBigStepLevels, m.name, m.apiDB, m.assertionConfirmingInterval, m.averageTimeForBlockCreation, m.trackChallengeParentAssertionHashes)
+	watcher, err := watcher.New(m.chain, m, m.stateManager, m.backend, m.chainWatcherInterval, numBigStepLevels, m.name, m.apiDB, m.assertionConfirmingInterval, m.averageTimeForBlockCreation, m.challengesToTrack)
 	if err != nil {
 		return nil, err
 	}

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -177,7 +177,7 @@ func setupEdgeTrackersForBisection(
 	require.NoError(t, err)
 	numBigStepLevels := numBigStepLevelsRaw
 
-	honestWatcher, err := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice", nil, honestValidator.assertionConfirmingInterval, honestValidator.averageTimeForBlockCreation)
+	honestWatcher, err := watcher.New(honestValidator.chain, honestValidator, honestValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice", nil, honestValidator.assertionConfirmingInterval, honestValidator.averageTimeForBlockCreation, nil)
 	require.NoError(t, err)
 	honestValidator.watcher = honestWatcher
 	assertionInfo := &edgetracker.AssociatedAssertionMetadata{
@@ -198,7 +198,7 @@ func setupEdgeTrackersForBisection(
 	)
 	require.NoError(t, err)
 
-	evilWatcher, err := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice", nil, evilValidator.assertionConfirmingInterval, evilValidator.averageTimeForBlockCreation)
+	evilWatcher, err := watcher.New(evilValidator.chain, evilValidator, evilValidator.stateManager, createdData.Backend, time.Second, numBigStepLevels, "alice", nil, evilValidator.assertionConfirmingInterval, evilValidator.averageTimeForBlockCreation, nil)
 	require.NoError(t, err)
 	evilValidator.watcher = evilWatcher
 	tracker2, err := edgetracker.New(

--- a/challenge-manager/manager_test.go
+++ b/challenge-manager/manager_test.go
@@ -149,7 +149,7 @@ func setupEdgeTrackersForBisection(
 	)
 	require.NoError(t, err)
 
-	honestEdge, _, _, err := honestValidator.addBlockChallengeLevelZeroEdge(ctx, createdData.Leaf1)
+	honestEdge, _, _, _, err := honestValidator.addBlockChallengeLevelZeroEdge(ctx, createdData.Leaf1)
 	require.NoError(t, err)
 
 	// If we specify an optional amount of blocks to delay the evil root edge creation by, do so
@@ -161,7 +161,7 @@ func setupEdgeTrackersForBisection(
 		}
 	}
 
-	evilEdge, _, _, err := evilValidator.addBlockChallengeLevelZeroEdge(ctx, createdData.Leaf2)
+	evilEdge, _, _, _, err := evilValidator.addBlockChallengeLevelZeroEdge(ctx, createdData.Leaf2)
 	require.NoError(t, err)
 
 	// Check unrivaled statuses.


### PR DESCRIPTION
PR from upstream by @amsanghi

`Only track edge for the specified parent assertion hashes. Track all if empty / nil.`